### PR TITLE
feat(code): support Objective-C syntax highlighting

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8bc4397f7f8827eb9da5a2fb38c45283499892d7c437674bb34138569968e519",
+  "originHash" : "302163d63c20b928f2610fada8351ba2cd32ba67b67ba453b59861e50ed9fd28",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
@@ -29,12 +29,38 @@
       }
     },
     {
+      "identity" : "swifttreesitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/SwiftTreeSitter",
+      "state" : {
+        "revision" : "08ef81eb8620617b55b08868126707ad72bf754f",
+        "version" : "0.25.0"
+      }
+    },
+    {
       "identity" : "syntaxink",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mtj0928/SyntaxInk",
+      "location" : "https://github.com/lynnswap/SyntaxInk.git",
       "state" : {
-        "revision" : "66fea7139f8e27cc2ac7c42fa9a5167c59685e16",
-        "version" : "0.0.2"
+        "revision" : "7ecf1c431397ab74d9bcdc325bd7932952ff4694"
+      }
+    },
+    {
+      "identity" : "tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter",
+      "state" : {
+        "revision" : "da6fe9beb4f7f67beb75914ca8e0d48ae48d6406",
+        "version" : "0.25.10"
+      }
+    },
+    {
+      "identity" : "tree-sitter-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-objc",
+      "state" : {
+        "revision" : "18802acf31d0b5c1c1d50bdbc9eb0e1636cab9ed",
+        "version" : "3.0.2"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "302163d63c20b928f2610fada8351ba2cd32ba67b67ba453b59861e50ed9fd28",
+  "originHash" : "69fe0a03893b7108e050797c80d1b81689e9337bd347b230c703ad939dd03e15",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
@@ -42,7 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxInk.git",
       "state" : {
-        "revision" : "7ecf1c431397ab74d9bcdc325bd7932952ff4694"
+        "revision" : "047f2c801bdffb94e89c660271b34254865fe13e",
+        "version" : "0.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "601.0.0"),
-        .package(url: "https://github.com/lynnswap/SyntaxInk.git", revision: "2a4a69bb28e6fee97f57b75b4f9f813eb5d775fb"),
+        .package(url: "https://github.com/lynnswap/SyntaxInk", from: "0.0.3"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -13,13 +13,14 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "601.0.0"),
-        .package(url: "https://github.com/mtj0928/SyntaxInk", from: "0.0.2"),
+        .package(url: "https://github.com/lynnswap/SyntaxInk.git", revision: "2a4a69bb28e6fee97f57b75b4f9f813eb5d775fb"),
     ],
     targets: [
         .target(
             name: "SlideKit",
             dependencies: [
                 "SlideKitMacros",
+                .product(name: "ObjCSyntaxInk", package: "SyntaxInk"),
                 .product(name: "SwiftSyntaxInk", package: "SyntaxInk"),
                 .product(name: "SyntaxInk", package: "SyntaxInk")
             ]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you want to know more details, refer the [DocC Style Document](https://mtj092
 - [x] Provide `HeaderSlide`, it is a template slide which has a title.
 - [x] Support `HeaderSlideStyle`, so you can customize the design of the `HeaderSlide`.
 - [x] Provide some utility view components
-    - `Code`: Syntax Highlighted view (Only Swift is supported now.)
+    - `Code`: Syntax highlighted view for Swift and Objective-C.
     - `Item`: Itemization view. `Item` supports nested structures.
 - [x] Show the current slide index at bottom right on slide.
 - [x] Support two windows, presentation window and presenter window.
@@ -53,6 +53,21 @@ struct IntroductionSlide: View {
 ```
 And then, this is the result of the code.  
 <img width="1096" alt="IntroductionSlide" src="https://user-images.githubusercontent.com/12427733/190955403-ed64a5fd-eed0-4a4c-8684-75f39623a563.png">
+
+## Syntax Highlighting
+If you want to highlight Objective-C, use `ObjCSyntaxHighlighter`.
+
+```swift
+import ObjCSyntaxInk
+
+let sourceCode = """
+@interface UIScrollView ()
+- (BOOL)_scrollToTopIfPossible:(BOOL)animated;
+@end
+"""
+
+Code(sourceCode, syntaxHighlighter: ObjCSyntaxHighlighter.presentation(fontSize: 32))
+```
 
 ## Presentations made with SlideKit
 Feel free to add your presentations made by SlideKit to the following list!!

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ let sourceCode = """
 @end
 """
 
-Code(sourceCode, syntaxHighlighter: ObjCSyntaxHighlighter.presentation(fontSize: 32))
+Code(sourceCode, objcSyntaxHighlighter: .presentation(fontSize: 32))
 ```
 
 ## Presentations made with SlideKit

--- a/SlideKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SlideKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "357f3587d6f7aa37a8fd2c9822ac1019b1f4fab1572ebe3e7c46118a42ea558a",
+  "originHash" : "4a2058dad694871a62aedbef4fb54d43982e9868350165f7c38596d1da40898b",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
@@ -29,12 +29,38 @@
       }
     },
     {
+      "identity" : "swifttreesitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ChimeHQ/SwiftTreeSitter",
+      "state" : {
+        "revision" : "08ef81eb8620617b55b08868126707ad72bf754f",
+        "version" : "0.25.0"
+      }
+    },
+    {
       "identity" : "syntaxink",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mtj0928/SyntaxInk.git",
+      "location" : "https://github.com/lynnswap/SyntaxInk.git",
       "state" : {
-        "revision" : "66fea7139f8e27cc2ac7c42fa9a5167c59685e16",
-        "version" : "0.0.2"
+        "revision" : "7ecf1c431397ab74d9bcdc325bd7932952ff4694"
+      }
+    },
+    {
+      "identity" : "tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter",
+      "state" : {
+        "revision" : "da6fe9beb4f7f67beb75914ca8e0d48ae48d6406",
+        "version" : "0.25.10"
+      }
+    },
+    {
+      "identity" : "tree-sitter-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-objc",
+      "state" : {
+        "revision" : "18802acf31d0b5c1c1d50bdbc9eb0e1636cab9ed",
+        "version" : "3.0.2"
       }
     }
   ],

--- a/SlideKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SlideKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4a2058dad694871a62aedbef4fb54d43982e9868350165f7c38596d1da40898b",
+  "originHash" : "bf7ae447cb7dab519263996774e6b881a06ad36bdbee98d497a362d7702c069b",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
@@ -42,7 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/SyntaxInk.git",
       "state" : {
-        "revision" : "7ecf1c431397ab74d9bcdc325bd7932952ff4694"
+        "revision" : "047f2c801bdffb94e89c660271b34254865fe13e",
+        "version" : "0.0.3"
       }
     },
     {

--- a/Sources/SlideKit/SlideComponents/Code/Code.swift
+++ b/Sources/SlideKit/SlideComponents/Code/Code.swift
@@ -1,3 +1,4 @@
+import ObjCSyntaxInk
 import SwiftSyntaxInk
 import SyntaxInk
 import SwiftUI
@@ -18,6 +19,14 @@ public struct Code<
         _ code: String,
         syntaxHighlighter: SwiftSyntaxHighlighter = .presentation
     ) where Grammar == SwiftGrammar, Theme == SwiftTheme {
+        self.code = code
+        self.syntaxHighlighter = syntaxHighlighter
+    }
+
+    public init(
+        _ code: String,
+        syntaxHighlighter: ObjCSyntaxHighlighter
+    ) where Grammar == ObjCGrammar, Theme == ObjCTheme {
         self.code = code
         self.syntaxHighlighter = syntaxHighlighter
     }

--- a/Sources/SlideKit/SlideComponents/Code/Code.swift
+++ b/Sources/SlideKit/SlideComponents/Code/Code.swift
@@ -25,10 +25,10 @@ public struct Code<
 
     public init(
         _ code: String,
-        syntaxHighlighter: ObjCSyntaxHighlighter
+        objcSyntaxHighlighter: ObjCSyntaxHighlighter
     ) where Grammar == ObjCGrammar, Theme == ObjCTheme {
         self.code = code
-        self.syntaxHighlighter = syntaxHighlighter
+        self.syntaxHighlighter = objcSyntaxHighlighter
     }
 
     public var body: some View {

--- a/Sources/SlideKit/SlideComponents/Code/SyntaxHighlighter+DefaultTheme.swift
+++ b/Sources/SlideKit/SlideComponents/Code/SyntaxHighlighter+DefaultTheme.swift
@@ -1,3 +1,4 @@
+import ObjCSyntaxInk
 import SwiftSyntaxInk
 import SyntaxInk
 import SwiftUI
@@ -92,6 +93,37 @@ extension SyntaxHighlighter where Self == SwiftSyntaxHighlighter {
             }
             return base
         })
+    }
+}
+
+extension SyntaxHighlighter where Self == ObjCSyntaxHighlighter {
+
+    /// A color theme matching Xcode's "Presentation" theme for Objective-C
+    public static var presentation: Self {
+        presentation(fontSize: 48)
+    }
+
+    /// A color theme matching Xcode's "Presentation" theme for Objective-C
+    public static func presentation(fontSize: CGFloat) -> Self {
+        let base = SyntaxStyle(
+            font: .custom(name: "Menlo", size: fontSize, weight: .regular),
+            color: SyntaxColor(red: 0, green: 0, blue: 0)
+        )
+        return ObjCSyntaxHighlighter(theme: .presentationLight(base))
+    }
+
+    /// A color theme matching Xcode's "Presentation Dark" theme for Objective-C
+    public static var presentationDark: Self {
+        presentationDark(fontSize: 48)
+    }
+
+    /// A color theme matching Xcode's "Presentation Dark" theme for Objective-C
+    public static func presentationDark(fontSize: CGFloat) -> Self {
+        let base = SyntaxStyle(
+            font: .custom(name: "Menlo", size: fontSize, weight: .regular),
+            color: SyntaxColor(red: 255, green: 255, blue: 255)
+        )
+        return ObjCSyntaxHighlighter(theme: .presentationDark(base))
     }
 }
 

--- a/Sources/SlideKit/SlideKit.docc/SlideKit.md
+++ b/Sources/SlideKit/SlideKit.docc/SlideKit.md
@@ -29,6 +29,20 @@ struct IntroductionSlide: View {
 And this is the result of the example.
 ![A screen shot of the result above sample code](IntroductionSlide.png)
 
+`Code` also supports Objective-C when you provide an `ObjCSyntaxHighlighter`.
+
+```swift
+import ObjCSyntaxInk
+
+let sourceCode = """
+@interface UIScrollView ()
+- (BOOL)_scrollToTopIfPossible:(BOOL)animated;
+@end
+"""
+
+Code(sourceCode, syntaxHighlighter: ObjCSyntaxHighlighter.presentation(fontSize: 32))
+```
+
 ## Topics
 
 ### Essentials
@@ -52,4 +66,3 @@ And this is the result of the example.
 - ``HeaderSlideStyle``
 - ``ItemStyle`` 
 - ``SlideTheme``
-

--- a/Sources/SlideKit/SlideKit.docc/SlideKit.md
+++ b/Sources/SlideKit/SlideKit.docc/SlideKit.md
@@ -40,7 +40,7 @@ let sourceCode = """
 @end
 """
 
-Code(sourceCode, syntaxHighlighter: ObjCSyntaxHighlighter.presentation(fontSize: 32))
+Code(sourceCode, objcSyntaxHighlighter: .presentation(fontSize: 32))
 ```
 
 ## Topics


### PR DESCRIPTION
## Summary
- switch `SyntaxInk` to `lynnswap/SyntaxInk` 0.0.3 and include `ObjCSyntaxInk` in the `SlideKit` target
- add Objective-C support to `Code` with a dedicated `objcSyntaxHighlighter` entry point while preserving existing Swift `.presentation(...)` call sites
- add Objective-C `presentation` and `presentationDark` theme helpers plus update the README and DocC overview examples

## Testing
- `xcodebuild build -workspace /Users/kn/Dev/TrySwift_Playgrounds/SlideKit/SlideKit.xcworkspace -scheme SlideKit-Package -destination 'platform=macOS' -disableAutomaticPackageResolution`
- `xcodebuild test -workspace /Users/kn/Dev/TrySwift_Playgrounds/SlideKit/SlideKit.xcworkspace -scheme SlideKit-Package -destination 'platform=macOS' -disableAutomaticPackageResolution`

## Notes
- This branch contains the same changes that were validated and merged in [`lynnswap/SlideKit` PR #1](https://github.com/lynnswap/SlideKit/pull/1), recreated as a branch so it can be proposed upstream.
